### PR TITLE
Fix fly.io config and deploy script

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -12,10 +12,6 @@ primary_region = 'fra'
   [build.args]
     BUILDKIT_INLINE_CACHE = '1'
 
-  [build.settings]
-    builder = 'local'
-    buildpacks = []
-
 [env]
   APP_ENV = 'production'
   APP_URL = 'https://api.fixmymind.org'
@@ -29,7 +25,7 @@ primary_region = 'fra'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = true
   auto_start_machines = true
   min_machines_running = 0
   processes = ['app']

--- a/start-prod.sh
+++ b/start-prod.sh
@@ -2,4 +2,4 @@
 
 echo "🚀 Deploy na produkcję (Fly.io)..."
 
-fly deploy --config fly.prod.toml
+fly deploy --config fly.toml


### PR DESCRIPTION
## Summary
- remove invalid fly.io build settings and restore `auto_stop_machines` boolean
- update production deploy script to use `fly.toml`

## Testing
- `bash test-php-fpm-config.sh`
- `bash test-nginx-config.sh`


------
https://chatgpt.com/codex/tasks/task_e_687af7e6cd0483229979a4ec0a22b8ee