### PR TITLE
Fix fly.io deploy script and start process selection

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -12,6 +12,22 @@ php artisan view:cache
 chown -R www-data:www-data /var/www/html/storage
 chown -R www-data:www-data /var/www/html/bootstrap/cache
 
-
-# Uruchom Supervisor z wygenerowaną konfiguracją
-exec /usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf
+# W zależności od roli uruchom odpowiednią usługę
+case "$APP_ROLE" in
+    "web")
+        exec php-fpm
+        ;;
+    "dev")
+        exec php artisan serve --host=0.0.0.0 --port=8080
+        ;;
+    "test")
+        exec php artisan test
+        ;;
+    "worker")
+        exec php artisan queue:work --sleep=3 --tries=3 --max-time=3600
+        ;;
+    "all"|*)
+        # Domyślnie uruchamiamy cały zestaw procesów przez Supervisora
+        exec /usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf
+        ;;
+esac

--- a/fly.toml
+++ b/fly.toml
@@ -12,10 +12,6 @@ primary_region = 'fra'
   [build.args]
     BUILDKIT_INLINE_CACHE = '1'
 
-  [build.settings]
-    builder = 'local'
-    buildpacks = []
-
 [env]
   APP_ENV = 'production'
   APP_URL = 'https://api.fixmymind.org'
@@ -29,7 +25,7 @@ primary_region = 'fra'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = true
   auto_start_machines = true
   min_machines_running = 0
   processes = ['app']
@@ -72,7 +68,7 @@ primary_region = 'fra'
     protocol = 'http'
     tls_skip_verify = false
 
-[[vm]]
+[vm]
   memory = '1gb'
   cpu_kind = 'shared'
   cpus = 1

--- a/start-prod.sh
+++ b/start-prod.sh
@@ -2,4 +2,4 @@
 
 echo "🚀 Deploy na produkcję (Fly.io)..."
 
-fly deploy --config fly.prod.toml
+fly deploy --config fly.toml --remote-only


### PR DESCRIPTION
## Summary
- make `start.sh` handle different `APP_ROLE` values so tests pass
- keep Fly.io config from previous work

## Testing
- `bash test-php-fpm-config.sh`
- `bash test-nginx-config.sh`
- `bash test-docker.sh`
- `bash test-build.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687af7e6cd0483229979a4ec0a22b8ee